### PR TITLE
Changing the master/slave vocabulary

### DIFF
--- a/recommend/management/commands/get_local_data.py
+++ b/recommend/management/commands/get_local_data.py
@@ -147,13 +147,13 @@ def get_systag_data():
 
     # 用相似词将keyword扩充
     num = 20
-    master_slave = {}
+    main_subordinate = {}
     high_freq_words = get_high_freq_words()
 
     for k in data['keyword']:
         systag_id_list = data['keyword'][k]
         # data['keyword_extend'][k] = [systag_id_list, 1.0]
-        master_slave[k] = [systag_id_list, []]
+        main_subordinate[k] = [systag_id_list, []]
         for w, s in get_similar_redis(k, num):
             w = ensure_unicode(w)
             if len(w) < 2:
@@ -167,7 +167,7 @@ def get_systag_data():
                 continue
 
             data['keyword_extend'][w] = [systag_id_list, s]
-            master_slave[k][1].append([w, s])
+            main_subordinate[k][1].append([w, s])
 
     for k in data['keyword']:
         systag_id_list = data['keyword'][k]
@@ -175,8 +175,8 @@ def get_systag_data():
 
     # 把keyword_extend信息存文件里，方便查看
     with open(SYSTAG_DATA_CHECK_FILE, 'w') as fc:
-        for k in master_slave:
-            systag_id_list, ws_list = master_slave[k]
+        for k in main_subordinate:
+            systag_id_list, ws_list = main_subordinate[k]
             fc.write('###' + k + '|||' + json.dumps(systag_id_list) + '=' * 10 + '\n')
             for w, s in ws_list:
                 fc.write(w + '|||' + str(s) + '\n')

--- a/recommend/test_scripts/test.py
+++ b/recommend/test_scripts/test.py
@@ -501,15 +501,15 @@ def test17():
             cnt += 1
             l = l.strip('\n')
             this_dict = json.loads(l)
-            master_id = this_dict['id']
-            master_title = nat_get_title(mtype + '_' + str(master_id))
-            if not master_title:
+            main_id = this_dict['id']
+            main_title = nat_get_title(mtype + '_' + str(main_id))
+            if not main_title:
                 continue
             top = this_dict['top'][:10]
-            for slave_id, score in top:
-                slave_title = nat_get_title(mtype + '_' + str(slave_id))
-                row = [str(master_id), master_title,
-                       str(slave_id), slave_title, str(score)]
+            for subordinate_id, score in top:
+                subordinate_title = nat_get_title(mtype + '_' + str(subordinate_id))
+                row = [str(main_id), main_title,
+                       str(subordinate_id), subordinate_title, str(score)]
                 row = convert2gbk(row)
                 csvwriter.writerow(row)
     fo.close()


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.